### PR TITLE
Properly initialize p_i; replace ran_mwc() with rand()

### DIFF
--- a/sampler/sampler.f90
+++ b/sampler/sampler.f90
@@ -1159,7 +1159,7 @@ program sampler
 
                     ! assign the galaxy to the closest halo mass in the mass bin
                     fom_old=abs(mgal-cone(istart_i,1)) !initialise distance betweem model mass and halo mass
-                    p_i=istart_i 
+                    p_i=istart_i+1
 
                     do iii=istart_i+1,iend_i
                        fom=abs(mgal-cone(iii,1))
@@ -1873,7 +1873,7 @@ program sampler
 !!$                    ! assign the galaxy to the closest halo mass in the mass bin
                        fom_old=abs(mgal-cone(istart_i,1)) !initialise distance betweem model mass and halo mass
                        ! associate galaxy to the closest available mass
-                       p_i=istart_i 
+                       p_i=istart_i+1
                        do iii=istart_i+1,iend_i
                           fom=abs(mgal-cone(iii,1))
                           if (fom<fom_old) then

--- a/sampler/sampler_modules.f90
+++ b/sampler/sampler_modules.f90
@@ -315,69 +315,13 @@ contains
     return
   end function rms
 
-  !=======================================================================
+
   function ran_mwc(iseed)
-    !=======================================================================
-    !     This routine implements the Marsaglia "multiply with carry method"
-    !     and adds a Marsaglia shift sequence to it.
-    !     (cf. references at http://www.cs.hku.hk/)
-    !     You are welcome to replace this with your preferred generator
-    !     of uniform variates in the interval ]0,1[ (i.e. excluding 0 and 1)
-
-    !     (Re-)initialise with setting iseed to a negative number.
-    !     Note that iseed=0 gives the same sequence as iseed=-1
-    !     After initialisation iseed becomes abs(iseed) (or 1 if it was 0).
-
-    !     B. D. Wandelt, May 1999
-    !=======================================================================
     implicit none
-    integer(I4B), intent(inout):: iseed
-    real(SP) :: ran_mwc
+    integer(I4B)::iseed
+    real(SP)::ran_mwc
 
-    integer(I4B) :: i,iseedl,iseedu,mwc,combined
-    integer(I4B),save :: upper,lower,shifter
-    integer(I4B),parameter :: mask16=65535,mask30=2147483647
-    real(SP),save :: small
-    logical(lgt), save :: first=.true.
-    
-    if (first.or.iseed<=0) then
-       if(iseed==0) iseed=-1
-       iseed=abs(iseed)
-       small=nearest(1.0_sp,-1.0_sp)/mask30
-
-       ! Users often enter small seeds - I spread them out using the
-       ! Marsaglia shifter a few times.
-       shifter=iseed
-       do i=1,9
-          shifter=ieor(shifter,ishft(shifter,13))
-          shifter=ieor(shifter,ishft(shifter,-17))
-          shifter=ieor(shifter,ishft(shifter,5))
-       enddo
-
-       iseedu=ishft(shifter,-16)
-       upper=ishft(iseedu+8765,16)+iseedu !This avoids the fixed points.
-       iseedl=iand(shifter,mask16)
-       lower=ishft(iseedl+4321,16)+iseedl !This avoids the fixed points.
-
-       first=.false.
-    endif
-
-100 continue
-
-    shifter=ieor(shifter,ishft(shifter,13))
-    shifter=ieor(shifter,ishft(shifter,-17))
-    shifter=ieor(shifter,ishft(shifter,5))
-    
-    upper=36969*iand(upper,mask16)+ishft(upper,-16)
-    lower=18000*iand(lower,mask16)+ishft(lower,-16)
-
-    mwc=ishft(upper,16)+iand(lower,mask16)
-
-    combined=iand(mwc,mask30)+iand(shifter,mask30)
-
-    ran_mwc=small*iand(combined,mask30)
-    if(ran_mwc==0._sp) goto 100
-
+    ran_mwc = rand()
     return
   end function ran_mwc
 


### PR DESCRIPTION
Two separate issues:

1.[b798eee] In the event that the list of DM halos is exhausted, p_i will be left
at 0. This results in an invalid memory access and corruption of the
cone array.

2. [30fb6d0] ran_mwc() produces strongly biases samples. Replace with simple rand() function as stopgap.