### PR TITLE
Fixed missing argument in FTMAHD

### DIFF
--- a/src/sampler_io.f90
+++ b/src/sampler_io.f90
@@ -47,7 +47,7 @@ contains
     call FTGKEY(unit,'TFIELDS',test,comment,status)
     print*,test,status
 
-    if (status /=0)  call FTMAHD(unit,1,status)
+    if (status /=0)  call FTMAHD(unit,1,hdutype,status)
     
     print*,'ok',status
 


### PR DESCRIPTION
Compilation fails with modern versions of gfortran due to missing argument in FTMAHD.
Addresses the issue [#7](https://github.com/abonaldi/TRECS/issues/7)