### PR TITLE
Solved deprecation warning on NumPy float casting

### DIFF
--- a/python/xmatch_hi.py
+++ b/python/xmatch_hi.py
@@ -128,7 +128,7 @@ for i in range(len(redshift_names)):
 
     z=redshift_names[i]
 
-    if (np.float(z) >= zmin) and (np.float(z) <= zmax):
+    if (float(z) >= zmin) and (float(z) <= zmax):
 
         # for final slices file
         mask_z[i] = True


### PR DESCRIPTION
modified the python script xmatch_hi.py 

newest versions of numpy deprecated the casting function ``np.float()`` in favour of the built-in ``float()``